### PR TITLE
Update setup for R-CMD-check on GH Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
       - release
       - master
       - develop
+
   pull_request:
     branches:
       - release
@@ -22,11 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - {os: macOS-latest,   r: 'devel'}
-          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest,   r: 'release'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-        # - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -82,13 +83,32 @@ jobs:
 
       - name: Roxygenize
         run: |
-          devtools::document(roclets = c('rd', 'collate', 'namespace', 'vignette'))
+          devtools::document(roclets = c('rd', 'collate', 'namespace'))
+          devtools::document(roclets = c('vignette'))
         shell: Rscript {0}
 
       - name: Check
+        if: matrix.config.r != 'devel'
         env:
           _R_CHECK_CRAN_INCOMING_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          rcmdcheck::rcmdcheck(
+            args = c("--no-manual", "--as-cran"),
+            error_on = "warning",
+            check_dir = "check"
+          )
+        shell: Rscript {0}
+
+      - name: Check (R-devel)
+        if: matrix.config.r == 'devel'
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: |
+          rcmdcheck::rcmdcheck(
+            args = c("--no-manual", "--as-cran"),
+            error_on = "error",
+            check_dir = "check"
+          )
         shell: Rscript {0}
 
       - name: Show testthat output
@@ -102,3 +122,7 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
+
+      - name: Test coverage & upload report to Codecov
+        run: covr::codecov()
+        shell: Rscript {0}


### PR DESCRIPTION
Closes #31. 

It is unreasonable to run tests on `R-devel` or `R-oldrelease`, appropriate lines should be commented again in the setup file.